### PR TITLE
Fix activity-logs 500 on deploy by avoiding eager DB/user loads.

### DIFF
--- a/.cursor/rules/deploy.mdc
+++ b/.cursor/rules/deploy.mdc
@@ -1,0 +1,80 @@
+---
+description: Deploy ARKA HERO (and sibling apps) to Docker server via SSH when user says deploy
+alwaysApply: true
+---
+
+# Deploy Runbook (Docker server)
+
+When the user says **deploy** (or deploy + specific artisan/seed instructions), follow this runbook. Do **not** deploy without an explicit user request.
+
+## Security (non-negotiable)
+
+- Never store, commit, or write SSH passwords, DB passwords, JWT secrets, or `.env` values into repo docs, `MEMORY.md`, rules, chat artifacts, or scripts.
+- Access only via SSH host alias **`arka-docker`** (key-based). Do not embed passwords in commands.
+- Do not restart/rebuild unrelated containers or touch other apps unless the user names that app.
+- Forbidden unless explicitly requested: `migrate:fresh`, `db:wipe`, `migrate:reset`, mass `docker compose down`, force-push.
+
+## Server facts (no secrets)
+
+| Item | Value |
+|------|--------|
+| SSH alias | `arka-docker` → `skyone@192.168.32.146` |
+| Hostname | `saphire-one` |
+| Stack root | `/home/skyone/stack` |
+| Compose | `/home/skyone/stack/docker-compose.yml` |
+| Apps bind | host `~/stack/apps` → containers `/var/www` |
+| Network | `stack_appnet` |
+
+### ARKA HERO (default when user says deploy in this repo)
+
+| Item | Value |
+|------|--------|
+| Host path | `/home/skyone/stack/apps/app82/arka-hero` |
+| Container | `stack-php82-1` (PHP 8.2-FPM) |
+| Workdir in container | `/var/www/app82/arka-hero` |
+| Public URL | `http://192.168.32.146:8080` (also `/arka-hero/` on port 80) |
+| DB schema name | `arka_hero` (credentials only on server `.env` / compose — never copy here) |
+| Git remote on server | `https://github.com/frizkyramadhan/arka-hero.git` branch `main` |
+
+### Sibling apps (only if user asks)
+
+| App | Host path | Runtime | Notes |
+|-----|-----------|---------|--------|
+| irr-support | `~/stack/apps/app81/irr-support` | `stack-php81-1`, workdir `/var/www/app81/irr-support` | Port **8081** |
+| arka-fms | `~/stack/apps/app81/arka-fms` | Node container `stack-arka-fms` | Port **3000**; may need image rebuild after pull |
+| app74 / app81 / app82 public stubs | `~/stack/apps/app{74,81,82}/public` | php74/81/82 via nginx path prefixes | Placeholder `index.php` |
+
+New apps: place under `~/stack/apps/app{NN}/<name>`, add nginx conf if needed, document in `MEMORY.md` — do not invent paths.
+
+## Deploy workflow (ARKA HERO)
+
+1. **Local git**: `git status`, `git diff`, `git log -5`. If working tree dirty and user said deploy → stage relevant files, commit (follow repo commit style), then `git push origin HEAD`. Skip commit if clean; still push if ahead of remote.
+2. **Server pull** (non-interactive):
+
+```bash
+ssh -o BatchMode=yes arka-docker 'cd /home/skyone/stack/apps/app82/arka-hero && git pull --ff-only'
+```
+
+3. **Artisan** (only when needed), via:
+
+```bash
+ssh -o BatchMode=yes arka-docker 'docker exec -w /var/www/app82/arka-hero stack-php82-1 php artisan <CMD>'
+```
+
+### When to run which artisan
+
+- New/changed migrations in the deploy → `migrate --force`
+- User names a seeder / permission seeder in commit → `db:seed --class=ThatSeeder` only (never full seed)
+- Config/route/view cache concerns → `optimize:clear`
+- Composer lock changed → ask user before `composer install` inside container (or document if they confirm a standard path)
+- Unsure about a seeder on shared DB → ask before running
+
+4. **Report** to user: push result, pull SHA, artisan output, any errors. Remind not to paste secrets.
+
+## Adding a new app later
+
+1. Confirm PHP/Node version → choose `app74` / `app81` / `app82` (or new runtime service).
+2. Clone into `~/stack/apps/<bucket>/<app-name>`.
+3. Nginx: either path on `:80` in `nginx/conf.d/site.conf` or dedicated port conf (pattern: `arka-hero-port.conf` / `irr-support.conf`).
+4. Reload nginx: `docker exec stack-nginx-1 nginx -s reload` (only if conf changed).
+5. Update `MEMORY.md` inventory + this rule’s sibling table (paths only, no secrets).

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,6 +1,36 @@
 **Purpose**: AI's persistent knowledge base for project context and learnings - ARKA HERO HRMS
 **Last Updated**: 2026-07-29
 
+## Docker Server Inventory (192.168.32.146) — no secrets
+
+**Host**: `saphire-one` · SSH user `skyone` · Local SSH alias **`arka-docker`** (key `~/.ssh/id_ed25519_arka_deploy`)  
+**Stack**: `/home/skyone/stack` · Compose: `docker-compose.yml` · Network: `stack_appnet`  
+**Bind**: `~/stack/apps` → `/var/www` in nginx + all PHP-FPM containers  
+
+| Container | Role | Published ports |
+|-----------|------|-----------------|
+| `stack-nginx-1` | nginx 1.27 | `80`, `8080`, `8081` |
+| `stack-php74-1` | PHP 7.4-FPM | (internal 9000) |
+| `stack-php81-1` | PHP 8.1-FPM | (internal 9000) |
+| `stack-php82-1` | PHP 8.2-FPM | (internal 9000) |
+| `stack-mysql-1` | MySQL 8.0 | `127.0.0.1:3306` only |
+| `stack-phpmyadmin-1` | phpMyAdmin via `/pma/` | (via nginx) |
+| `stack-arka-fms` | Node ARKA FMS | `3000` |
+
+**Apps**
+
+| App | Host path | Container workdir | URL | DB dir name |
+|-----|-----------|-------------------|-----|-------------|
+| **arka-hero** | `apps/app82/arka-hero` | `/var/www/app82/arka-hero` on `stack-php82-1` | `:8080` (+ `/arka-hero/` on `:80`) | `arka_hero` |
+| irr-support | `apps/app81/irr-support` | `/var/www/app81/irr-support` on `stack-php81-1` | `:8081` | `irr5` |
+| arka-fms | `apps/app81/arka-fms` | Node image `stack-arka-fms` | `:3000` | `arka_fms` |
+| stubs | `apps/app{74,81,82}/public` | path prefixes `/app74/` `/app81/` `/app82/` | `:80` | `appdb` |
+
+**Deploy HERO**: user says `deploy` → commit/push if needed → `ssh arka-docker 'cd .../arka-hero && git pull --ff-only'` → `docker exec -w /var/www/app82/arka-hero stack-php82-1 php artisan …`  
+**Rule**: `.cursor/rules/deploy.mdc` · Never copy compose/DB/JWT passwords into this file.
+
+---
+
 ## Memory Maintenance Guidelines
 
 ### Structure Standards
@@ -26,6 +56,18 @@
 ---
 
 ## Project Memory Entries - ARKA HERO HRMS
+
+### [032] Docker deploy access + stack inventory (2026-07-29) ✅ COMPLETE
+
+**Challenge**: Manual deploy (push → SSH password → git pull → docker exec artisan); multi-app stack needs documented layout for future deploys without storing credentials.
+
+**Solution**: Passwordless SSH alias `arka-docker`; Cursor rule `.cursor/rules/deploy.mdc`; inventory section above (paths/ports/containers only). Password used once for key install — not stored in repo.
+
+**Key Learning**: Host `~/stack/apps` mounts to `/var/www`; HERO artisan workdir is `/var/www/app82/arka-hero` in `stack-php82-1`. Never paste server secrets into MEMORY/rules.
+
+**Files**: `.cursor/rules/deploy.mdc`, `MEMORY.md` inventory, `docs/architecture.md` Deployment
+
+---
 
 ### [031] Leave update wiped approval_plans without recreate (2026-07-29) ✅ COMPLETE
 
@@ -327,15 +369,15 @@
 
 ---
 
-### TD-003: Missing Production Infrastructure ❌ BLOCKED
+### TD-003: Missing Production Infrastructure ⚠️ PARTIAL
 
-**Issue**: Application runs only on local Laragon development environment. No production deployment plan, no CI/CD pipeline, no monitoring/alerting, no automated backups.
+**Issue**: Staging Docker at `192.168.32.146` is documented + deployable via Cursor (`deploy` / `.cursor/rules/deploy.mdc`). Still no formal production CI/CD, monitoring/alerting, or automated backup runbook beyond `stack/backup/`.
 
-**Impact**: Cannot deploy to production safely. No disaster recovery plan. Manual deployment errors likely.
+**Impact**: Staging deploys are safer; true production hardening and disaster recovery remain open.
 
-**Recommendation**: Set up production server with proper configuration. Implement automated daily database backups. Configure monitoring/alerting. Setup CI/CD pipeline with GitHub Actions. Effort: 2 weeks.
+**Recommendation**: Formalize backups/monitoring; consider GitHub Actions later. Do not store server secrets in repo.
 
-**Status**: Critical blocker for production launch
+**Status**: Staging deploy OK; production CI/CD still open
 
 ---
 

--- a/app/Http/Controllers/ActivityLogController.php
+++ b/app/Http/Controllers/ActivityLogController.php
@@ -2,8 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Spatie\Activitylog\Models\Activity;
 
 class ActivityLogController extends Controller
@@ -21,14 +22,19 @@ class ActivityLogController extends Controller
             'document_approval' => 'Document Approval',
             'document_email' => 'Document Email',
         ];
-        $events = Activity::query()
-            ->whereIn('log_name', array_keys($logNames))
-            ->whereNotNull('event')
-            ->distinct()
-            ->orderBy('event')
-            ->pluck('event');
+        // Static list — avoid querying activity_log on page load (table/package may be missing after deploy)
+        $events = collect([
+            'submitted',
+            'step_approved',
+            'step_rejected',
+            'document_approved',
+            'document_rejected',
+            'email_sent',
+            'email_failed',
+            'email_skipped',
+        ]);
         $documentTypes = config('document_notifications.labels', []);
-        $users = User::orderBy('name')->get(['id', 'name', 'email']);
+        $tableReady = $this->activityLogTableReady();
 
         return view('activity-logs.index', compact(
             'title',
@@ -36,100 +42,152 @@ class ActivityLogController extends Controller
             'logNames',
             'events',
             'documentTypes',
-            'users'
+            'tableReady'
         ));
     }
 
     public function data(Request $request)
     {
-        $query = Activity::query()
-            ->with(['causer'])
-            ->whereIn('log_name', ['document_approval', 'document_email'])
-            ->latest();
-
-        if ($request->filled('date_from')) {
-            $query->whereDate('created_at', '>=', $request->date_from);
+        if (! $this->activityLogTableReady()) {
+            return response()->json([
+                'draw' => (int) $request->get('draw', 0),
+                'recordsTotal' => 0,
+                'recordsFiltered' => 0,
+                'data' => [],
+                'error' => 'activity_log table is not ready. Run migrations for spatie/laravel-activitylog.',
+            ]);
         }
 
-        if ($request->filled('date_to')) {
-            $query->whereDate('created_at', '<=', $request->date_to);
+        try {
+            $query = Activity::query()
+                ->with(['causer'])
+                ->whereIn('log_name', ['document_approval', 'document_email'])
+                ->latest();
+
+            if ($request->filled('date_from')) {
+                $query->whereDate('created_at', '>=', $request->date_from);
+            }
+
+            if ($request->filled('date_to')) {
+                $query->whereDate('created_at', '<=', $request->date_to);
+            }
+
+            if ($request->filled('log_name')) {
+                $query->where('log_name', $request->log_name);
+            }
+
+            if ($request->filled('event')) {
+                $query->where('event', $request->event);
+            }
+
+            if ($request->filled('causer_id')) {
+                $query->where('causer_id', $request->causer_id);
+            }
+
+            if ($request->filled('causer')) {
+                $causer = $request->causer;
+                $query->whereHasMorph('causer', [\App\Models\User::class], function ($q) use ($causer) {
+                    $q->where('name', 'like', "%{$causer}%")
+                        ->orWhere('email', 'like', "%{$causer}%");
+                });
+            }
+
+            if ($request->filled('document_type')) {
+                $documentType = $request->document_type;
+                $query->where(function ($q) use ($documentType) {
+                    $q->where('properties->document_type', $documentType);
+                });
+            }
+
+            if ($request->filled('keyword')) {
+                $keyword = $request->keyword;
+                $query->where(function ($q) use ($keyword) {
+                    $q->where('description', 'like', "%{$keyword}%")
+                        ->orWhere('properties->reference', 'like', "%{$keyword}%")
+                        ->orWhere('properties->recipient_email', 'like', "%{$keyword}%")
+                        ->orWhere('properties->subject', 'like', "%{$keyword}%");
+                });
+            }
+
+            return datatables()->of($query)
+                ->addIndexColumn()
+                ->addColumn('created_at_formatted', function (Activity $activity) {
+                    return optional($activity->created_at)->format('d M Y H:i:s');
+                })
+                ->addColumn('log_name_label', function (Activity $activity) {
+                    return match ($activity->log_name) {
+                        'document_approval' => '<span class="badge badge-primary">Approval</span>',
+                        'document_email' => '<span class="badge badge-info">Email</span>',
+                        default => e((string) $activity->log_name),
+                    };
+                })
+                ->addColumn('event_label', function (Activity $activity) {
+                    return e($activity->event ?: '—');
+                })
+                ->addColumn('document_type_label', function (Activity $activity) {
+                    $type = data_get($activity->properties, 'document_type');
+                    $labels = config('document_notifications.labels', []);
+
+                    return e($labels[$type] ?? ($type ?: '—'));
+                })
+                ->addColumn('reference', function (Activity $activity) {
+                    return e(data_get($activity->properties, 'reference') ?: '—');
+                })
+                ->addColumn('causer_name', function (Activity $activity) {
+                    return e($activity->causer->name ?? 'System');
+                })
+                ->addColumn('description_short', function (Activity $activity) {
+                    return e(\Illuminate\Support\Str::limit($activity->description, 80));
+                })
+                ->addColumn('action', function (Activity $activity) {
+                    $url = route('activity-logs.show', $activity->id);
+
+                    return '<a href="'.$url.'" class="btn btn-sm btn-info" title="Detail"><i class="fas fa-eye"></i></a>';
+                })
+                ->rawColumns(['log_name_label', 'action'])
+                ->toJson();
+        } catch (\Throwable $e) {
+            Log::error('ActivityLogController::data failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return response()->json([
+                'draw' => (int) $request->get('draw', 0),
+                'recordsTotal' => 0,
+                'recordsFiltered' => 0,
+                'data' => [],
+                'error' => $e->getMessage(),
+            ], 500);
         }
-
-        if ($request->filled('log_name')) {
-            $query->where('log_name', $request->log_name);
-        }
-
-        if ($request->filled('event')) {
-            $query->where('event', $request->event);
-        }
-
-        if ($request->filled('causer_id')) {
-            $query->where('causer_id', $request->causer_id);
-        }
-
-        if ($request->filled('document_type')) {
-            $documentType = $request->document_type;
-            $query->where(function ($q) use ($documentType) {
-                $q->where('properties->document_type', $documentType);
-            });
-        }
-
-        if ($request->filled('keyword')) {
-            $keyword = $request->keyword;
-            $query->where(function ($q) use ($keyword) {
-                $q->where('description', 'like', "%{$keyword}%")
-                    ->orWhere('properties->reference', 'like', "%{$keyword}%")
-                    ->orWhere('properties->recipient_email', 'like', "%{$keyword}%")
-                    ->orWhere('properties->subject', 'like', "%{$keyword}%");
-            });
-        }
-
-        return datatables()->of($query)
-            ->addIndexColumn()
-            ->addColumn('created_at_formatted', function (Activity $activity) {
-                return optional($activity->created_at)->format('d M Y H:i:s');
-            })
-            ->addColumn('log_name_label', function (Activity $activity) {
-                return match ($activity->log_name) {
-                    'document_approval' => '<span class="badge badge-primary">Approval</span>',
-                    'document_email' => '<span class="badge badge-info">Email</span>',
-                    default => e($activity->log_name),
-                };
-            })
-            ->addColumn('event_label', function (Activity $activity) {
-                return e($activity->event ?: '—');
-            })
-            ->addColumn('document_type_label', function (Activity $activity) {
-                $type = data_get($activity->properties, 'document_type');
-                $labels = config('document_notifications.labels', []);
-
-                return e($labels[$type] ?? ($type ?: '—'));
-            })
-            ->addColumn('reference', function (Activity $activity) {
-                return e(data_get($activity->properties, 'reference') ?: '—');
-            })
-            ->addColumn('causer_name', function (Activity $activity) {
-                return e($activity->causer->name ?? 'System');
-            })
-            ->addColumn('description_short', function (Activity $activity) {
-                return e(\Illuminate\Support\Str::limit($activity->description, 80));
-            })
-            ->addColumn('action', function (Activity $activity) {
-                $url = route('activity-logs.show', $activity->id);
-
-                return '<a href="'.$url.'" class="btn btn-sm btn-info" title="Detail"><i class="fas fa-eye"></i></a>';
-            })
-            ->rawColumns(['log_name_label', 'action'])
-            ->toJson();
     }
 
     public function show($id)
     {
+        if (! $this->activityLogTableReady()) {
+            return redirect()->route('activity-logs.index')
+                ->with('toast_error', 'activity_log table is not ready. Run migrations first.');
+        }
+
         $activity = Activity::with(['causer', 'subject'])->findOrFail($id);
         $title = 'Activity Log Detail';
         $subtitle = 'Log #'.$activity->id;
         $labels = config('document_notifications.labels', []);
 
         return view('activity-logs.show', compact('activity', 'title', 'subtitle', 'labels'));
+    }
+
+    protected function activityLogTableReady(): bool
+    {
+        try {
+            if (! class_exists(Activity::class)) {
+                return false;
+            }
+
+            return Schema::hasTable(config('activitylog.table_name', 'activity_log'));
+        } catch (\Throwable $e) {
+            Log::warning('activity_log readiness check failed', ['error' => $e->getMessage()]);
+
+            return false;
+        }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -826,6 +826,16 @@ Error response:
 - **MySQL**: Latest version via Laragon
 - **Node.js**: For asset compilation (npm/Vite)
 
+### Shared Docker Staging Server (`192.168.32.146`)
+
+- **Host**: `saphire-one` · SSH user `skyone` · Local alias `arka-docker` (SSH key; no password in repo)
+- **Stack root**: `/home/skyone/stack` · Compose drives nginx, MySQL 8, phpMyAdmin, PHP-FPM 7.4/8.1/8.2, optional Node (`stack-arka-fms`)
+- **Apps mount**: host `stack/apps` → container `/var/www`
+- **ARKA HERO**: `stack/apps/app82/arka-hero` · runtime `stack-php82-1` · workdir `/var/www/app82/arka-hero` · URL `http://192.168.32.146:8080`
+- **Sibling apps** (same stack): irr-support (`app81`, PHP 8.1, `:8081`), arka-fms (Node, `:3000`)
+- **Deploy trigger**: user says `deploy` → follow `.cursor/rules/deploy.mdc` (push → `git pull` on server → selective `php artisan`)
+- **Secrets**: live only in server compose / app `.env` — never document passwords, JWT, or DB URLs here (see `MEMORY.md` inventory for paths only)
+
 ### Application Structure
 
 ```

--- a/resources/views/activity-logs/index.blade.php
+++ b/resources/views/activity-logs/index.blade.php
@@ -65,14 +65,18 @@
                 </div>
                 <div class="col-md-2">
                   <label>Causer</label>
-                  <select name="causer_id" class="form-control form-control-sm">
-                    <option value="">All</option>
-                    @foreach($users as $user)
-                      <option value="{{ $user->id }}">{{ $user->name }}</option>
-                    @endforeach
-                  </select>
+                  <input type="text" name="causer" class="form-control form-control-sm"
+                         placeholder="Name or email">
                 </div>
               </div>
+              @if(isset($tableReady) && ! $tableReady)
+                <div class="alert alert-warning mt-3 mb-0">
+                  <strong>activity_log</strong> is not ready on this environment.
+                  Run <code>composer install</code> and
+                  <code>php artisan migrate</code> (Spatie activitylog migrations),
+                  then <code>php artisan db:seed --class=ActivityLogPermissionSeeder</code>.
+                </div>
+              @endif
               <div class="row mt-2">
                 <div class="col-md-6">
                   <label>Keyword</label>


### PR DESCRIPTION
Index no longer queries activity_log for filter options and skips loading all users; shows a readiness warning instead of crashing when the table is missing.