### PR TITLE
Fix Leave Requests DataTables 403 on server-side data load.

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,5 +1,17 @@
 **Purpose**: AI's persistent knowledge base for project context and learnings - ARKA HERO HRMS
-**Last Updated**: 2026-07-31
+**Last Updated**: 2026-08-03
+
+### [042] Leave Requests DataTables 403 (2026-08-03) ✅ FIXED
+
+**Challenge**: Some users saw DataTables Ajax error on Leave Requests; console showed **403** on server-side JSON (`leave/requests/data`) while the HTML page still loaded.
+
+**Cause**: `AppServiceProvider` calls `URL::forceRootUrl(APP_URL)`. Absolute `route()` URLs in DataTables AJAX can point at the other entry (`:8080` vs `:80/arka-hero/`). Different origin → session cookie not sent → Spatie `PermissionMiddleware` throws `UnauthorizedException::notLoggedIn()` (**403**). Also, long GET query strings with `columns[n][...]` are often blocked by WAF/ModSecurity (HTTP 403).
+
+**Fix**: Leave DataTables AJAX uses (1) URL derived from `window.location.pathname` + `/data`, (2) **POST** + CSRF so `columns[n][...]` is not in the query string. Routes: `match(['get','post'], …/data)`. Handler returns real HTTP 403 JSON for AJAX unauthorized.
+
+**Files**: `leave-requests/index.blade.php`, `my-requests.blade.php`, `routes/web.php`, `app/Exceptions/Handler.php`
+
+---
 
 ## Docker Server Inventory (192.168.32.146) — no secrets
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -46,12 +46,12 @@ class Handler extends ExceptionHandler
     public function register(): void
     {
         $this->renderable(function (\Spatie\Permission\Exceptions\UnauthorizedException $e, $request) {
-            if ($request->expectsJson()) {
-                // For API requests, return JSON response
+            // DataTables / jQuery XHR: ajax() + */* makes expectsJson() true — always return real HTTP 403 JSON
+            if ($request->expectsJson() || $request->ajax()) {
                 return response()->json([
                     'responseMessage' => 'You do not have the required authorization.',
-                    'responseStatus'  => 403,
-                ]);
+                    'responseStatus' => 403,
+                ], 403);
             }
 
             // For web requests, redirect with flash message for SweetAlert2

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,5 @@
 **Purpose**: Track current work and immediate priorities for ARKA HERO HRMS
-**Last Updated**: 2026-07-31
+**Last Updated**: 2026-08-03
 
 ## Task Management Guidelines
 
@@ -54,6 +54,7 @@ Include relevant context in brackets to help with future AI-assisted coding:
 
 ## Recently Completed
 
+-   `[done] P0: Leave Requests DataTables Ajax 403 — same-origin path + POST/CSRF for /data (avoid APP_URL mismatch and WAF on columns[n] GET) [leave-requests/index, my-requests, Handler, web.php] (completed: 2026-08-03)`
 -   `[done] P1: SPM letter number fields — periode magang, departemen ditempatkan, lembaga pendidikan [LetterNumberController case SPM, #spm-template create/edit/show, department_id + educational_institution migration, export/import] (completed: 2026-07-31)`
 -   `[done] P2: Clarify Activity Log email statistics [live Pending Queue vs 7-day Queued Events/Delivered/Failed/Skipped] (completed: 2026-07-31)`
 -   `[done] P1: Email notification Docker-ready improvements [database queue+ShouldQueue, CTA per event, 3-day reminder, config CC, idempotency, logo+plaintext, litmus, delivery metrics] (completed: 2026-07-30)`

--- a/resources/views/leave-requests/index.blade.php
+++ b/resources/views/leave-requests/index.blade.php
@@ -182,8 +182,13 @@
                 width: '100%'
             });
 
+            // Derive from current browser path (works for :8080 and /arka-hero) — never APP_URL/forceRootUrl.
+            var leavePageBase = window.location.pathname.replace(/\/?$/, '');
+            var leaveFilterOptionsUrl = leavePageBase + '/index-filter-options';
+            var leaveRequestsDataUrl = leavePageBase + '/data';
+
             // Filters: use web routes (session cookie). /api/* requires API key and fails from the browser.
-            $.getJSON('{{ route('leave.requests.index.filter-options') }}', function(res) {
+            $.getJSON(leaveFilterOptionsUrl, function(res) {
                 var $emp = $('#employee_id').empty().append('<option value="">- All -</option>');
                 $.each(res.employees || [], function(_, employee) {
                     $('<option>', {
@@ -212,7 +217,12 @@
                 processing: true,
                 serverSide: true,
                 ajax: {
-                    url: "{{ route('leave.requests.data') }}",
+                    // POST: columns[n][...] in query string often blocked by WAF/ModSecurity → HTTP 403
+                    url: leaveRequestsDataUrl,
+                    type: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                    },
                     data: function(d) {
                         d.status = $('#status').val();
                         d.employee_id = $('#employee_id').val();
@@ -220,6 +230,9 @@
                         d.project_id = $('#project_id').val();
                         d.start_date = $('#start_date').val();
                         d.end_date = $('#end_date').val();
+                    },
+                    error: function(xhr) {
+                        console.error('leave.requests.data failed', xhr.status, xhr.responseText);
                     }
                 },
                 columns: [{

--- a/resources/views/leave-requests/my-requests.blade.php
+++ b/resources/views/leave-requests/my-requests.blade.php
@@ -165,7 +165,12 @@
                 width: '100%'
             });
 
-            $.getJSON('{{ route('leave.my-requests.filter-options') }}', function(res) {
+            // Derive from current browser path (works for :8080 and /arka-hero).
+            var myLeavePageBase = window.location.pathname.replace(/\/?$/, '');
+            var myLeaveFilterOptionsUrl = myLeavePageBase + '/filter-options';
+            var myLeaveRequestsDataUrl = myLeavePageBase + '/data';
+
+            $.getJSON(myLeaveFilterOptionsUrl, function(res) {
                 var $lt = $('#leave_type_id').empty().append('<option value="">- All -</option>');
                 $.each(res.leave_types || [], function(_, leaveType) {
                     $('<option>', {
@@ -185,12 +190,19 @@
                 processing: true,
                 serverSide: true,
                 ajax: {
-                    url: "{{ route('leave.my-requests.data') }}",
+                    url: myLeaveRequestsDataUrl,
+                    type: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                    },
                     data: function(d) {
                         d.status = $('#status').val();
                         d.leave_type_id = $('#leave_type_id').val();
                         d.start_date = $('#start_date').val();
                         d.end_date = $('#end_date').val();
+                    },
+                    error: function(xhr) {
+                        console.error('leave.my-requests.data failed', xhr.status, xhr.responseText);
                     }
                 },
                 columns: [{

--- a/routes/web.php
+++ b/routes/web.php
@@ -749,7 +749,8 @@ Route::group(['middleware' => ['auth']], function () {
         // Leave Requests
         Route::prefix('requests')->name('requests.')->group(function () {
             Route::get('/', [LeaveRequestController::class, 'index'])->name('index');
-            Route::get('/data', [LeaveRequestController::class, 'data'])->name('data');
+            // POST preferred for DataTables (avoids WAF/ModSecurity 403 on columns[n][...] query strings)
+            Route::match(['get', 'post'], '/data', [LeaveRequestController::class, 'data'])->name('data');
             Route::get('/index-filter-options', [LeaveRequestController::class, 'indexFilterOptions'])->name('index.filter-options');
             Route::get('/create', [LeaveRequestController::class, 'create'])->name('create');
             Route::post('/', [LeaveRequestController::class, 'store'])->name('store');
@@ -785,7 +786,7 @@ Route::group(['middleware' => ['auth']], function () {
 
         // Self-service routes for user role (moved outside requests prefix)
         Route::get('/my-requests', [LeaveRequestController::class, 'myRequests'])->name('my-requests');
-        Route::get('/my-requests/data', [LeaveRequestController::class, 'myRequestsData'])->name('my-requests.data');
+        Route::match(['get', 'post'], '/my-requests/data', [LeaveRequestController::class, 'myRequestsData'])->name('my-requests.data');
         Route::get('/my-requests/filter-options', [LeaveRequestController::class, 'myRequestsFilterOptions'])->name('my-requests.filter-options');
         Route::get('/my-requests/create', [LeaveRequestController::class, 'myRequestsCreate'])->name('my-requests.create');
         Route::post('/my-requests', [LeaveRequestController::class, 'myRequestsStore'])->name('my-requests.store');


### PR DESCRIPTION
Use same-origin POST+/data with CSRF and return real HTTP 403 JSON for unauthorized AJAX so WAF and APP_URL host mismatch no longer break the table.